### PR TITLE
Fix role assignments scope and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ The following Modules are called:
 
 Source: Azure/avm-utl-interfaces/azure
 
-Version: 0.2.0
+Version: 0.5.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -1,6 +1,6 @@
 module "avm_interfaces" {
   source  = "Azure/avm-utl-interfaces/azure"
-  version = "0.2.0"
+  version = "0.5.0"
 
   enable_telemetry = var.enable_telemetry
   lock             = var.lock

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -16,7 +16,7 @@ resource "azapi_resource" "role_assignments" {
   for_each = module.avm_interfaces.role_assignments_azapi
 
   name           = each.value.name
-  parent_id      = local.resource_group_id
+  parent_id      = azapi_resource.container_app.id
   type           = each.value.type
   body           = each.value.body
   create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -29,7 +29,7 @@ resource "azapi_resource" "lock" {
   count = var.lock != null ? 1 : 0
 
   name           = module.avm_interfaces.lock_azapi.name != null ? module.avm_interfaces.lock_azapi.name : "lock-${azapi_resource.container_app.name}"
-  parent_id      = local.resource_group_id
+  parent_id      = azapi_resource.container_app.id
   type           = module.avm_interfaces.lock_azapi.type
   body           = module.avm_interfaces.lock_azapi.body
   create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -8,8 +8,9 @@ module "avm_interfaces" {
     system_assigned            = var.managed_identities.system_assigned
     user_assigned_resource_ids = var.managed_identities.user_assigned_resource_ids
   }
-  role_assignment_definition_scope = azapi_resource.container_app.id
-  role_assignments                 = var.role_assignments
+  role_assignment_definition_scope     = azapi_resource.container_app.id
+  role_assignment_name_use_random_uuid = true
+  role_assignments                     = var.role_assignments
 }
 
 resource "azapi_resource" "role_assignments" {


### PR DESCRIPTION
## Description

* Updated `parent_id` references for `azapi_resource` resources (`role_assignments` and `lock`) to use container app ID instead of resource group ID.
* Updated the `avm-utl-interfaces` module version from `0.2.0` to `0.5.0` in both `README.md` and `main.interfaces.tf` to align with the latest features and fixes.
* Enable `role_assignment_name_use_random_uuid` parameter to ensure unique naming for role assignments.

Fixes #93 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
