### PR TITLE
fix for secrets_version Issue in Azure Container Apps AVM Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,14 +990,6 @@ map(object({
 
 Default: `null`
 
-### <a name="input_secrets_version"></a> [secrets\_version](#input\_secrets\_version)
-
-Description: Version number for the secrets. Must set this version number to a different value to trigger an update on secrets. Defaults to `0`.
-
-Type: `number`
-
-Default: `0`
-
 ### <a name="input_service"></a> [service](#input\_service)
 
 Description: Service configuration for the Container App.

--- a/main.tf
+++ b/main.tf
@@ -212,9 +212,6 @@ resource "azapi_resource" "container_app" {
         ] : null
     } }
   } : null
-  sensitive_body_version = local.sensitive_body_present ? merge(nonsensitive(var.secrets == null) ? {} : {
-    "properties.configuration.secrets" = var.secrets_version
-  }, {}) : null
   tags           = var.tags
   update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 

--- a/variables.tf
+++ b/variables.tf
@@ -1017,13 +1017,6 @@ variable "secrets" {
 EOT
 }
 
-variable "secrets_version" {
-  type        = number
-  default     = 0
-  description = "Version number for the secrets. Must set this version number to a different value to trigger an update on secrets. Defaults to `0`."
-  nullable    = false
-}
-
 variable "service" {
   type = object({
     type = string


### PR DESCRIPTION
* fix(issue-92): removing secrets_version since it is breaking the functionality

* docs(issue-92): readme updated

## Description

Release pr for #95 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
