### PR TITLE
fix: remove static revisionSuffix from PUT body to prevent conflict error

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Description:  - `cooldown_period` - (Optional) The cooldown period in seconds af
  - `max_replicas` - (Optional) The maximum number of replicas for this container.
  - `min_replicas` - (Optional) The minimum number of replicas for this container.
  - `polling_interval` - (Optional) The interval in seconds at which the scaling rules are evaluated. Defaults to `30`.
- - `revision_suffix` - (Optional) The suffix for the revision. This value must be unique for the lifetime of the Resource. If omitted the service will use a hash function to create one.
+ - `revision_suffix` - (Optional - Deprecated) This field is no longer sent to Azure. Azure automatically generates a unique revision suffix using a hash function. Static values caused 'revision with suffix already exists' errors on subsequent applies (see [#115](https://github.com/Azure/terraform-azurerm-avm-res-app-containerapp/issues/115)). This variable is retained for backward compatibility but has no effect.
 
  ---
  `azure_queue_scale_rule` block supports the following:

--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,9 @@ resource "azapi_resource" "container_app" {
             ] : null
           }
         ] : null
-        revisionSuffix = var.template.revision_suffix
+        # revisionSuffix intentionally omitted — Azure auto-generates a unique
+        # suffix per revision. Sending a static value causes "revision with
+        # suffix already exists" errors on subsequent applies. See #115.
         scale = { for k, v in {
           minReplicas = var.template.min_replicas
           maxReplicas = var.template.max_replicas
@@ -250,7 +252,6 @@ resource "azapi_resource" "container_app" {
 
   lifecycle {
     ignore_changes = [
-      body.properties.template.revisionSuffix,
       body.properties.managedEnvironmentId,
       schema_validation_enabled,
       response_export_values,

--- a/tests/revision_suffix_bug/main.tf
+++ b/tests/revision_suffix_bug/main.tf
@@ -1,0 +1,73 @@
+# Reproduction test for Issue #115:
+# "Field template.revisionsuffix is invalid; revision with suffix already exists"
+#
+# Bug scenario (before fix):
+#   1. terraform apply  → creates container app with revision_suffix "test-v1" ✓
+#   2. terraform apply  → re-sends revisionSuffix "test-v1" → Azure rejects with
+#      "revision with suffix already exists" ✗
+#
+# After fix:
+#   revisionSuffix is no longer sent to Azure. Azure auto-generates a unique
+#   suffix, so consecutive applies never conflict.
+
+resource "random_id" "rg_name" {
+  byte_length = 8
+}
+
+resource "random_id" "container_name" {
+  byte_length = 4
+}
+
+resource "azurerm_resource_group" "test" {
+  location = "eastus"
+  name     = "rg-revision-suffix-bug-${random_id.rg_name.hex}"
+}
+
+resource "azurerm_container_app_environment" "test" {
+  location            = azurerm_resource_group.test.location
+  name                = "env-revision-suffix-bug"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+module "container_app" {
+  source = "../.."
+
+  container_app_environment_resource_id = azurerm_container_app_environment.test.id
+  name                                  = "app-suffix-bug-${random_id.container_name.hex}"
+  resource_group_name                   = azurerm_resource_group.test.name
+  revision_mode                         = "Single"
+  enable_telemetry                      = false
+
+  template = {
+    # Setting revision_suffix triggers the bug on the second apply.
+    # Before the fix, Azure rejects this because "test-v1" already exists.
+    # After the fix, this value is ignored — Azure auto-generates unique suffixes.
+    revision_suffix = "test-v1"
+
+    containers = [
+      {
+        name   = "hello"
+        memory = "0.5Gi"
+        cpu    = 0.25
+        image  = "mcr.microsoft.com/k8se/quickstart:latest"
+        env = [
+          {
+            name  = "PORT"
+            value = "80"
+          }
+        ]
+      },
+    ]
+  }
+
+  ingress = {
+    target_port      = 80
+    external_enabled = true
+    traffic_weight = [{
+      latest_revision = true
+      percentage      = 100
+    }]
+  }
+
+  depends_on = [azurerm_resource_group.test]
+}

--- a/tests/revision_suffix_bug/providers.tf
+++ b/tests/revision_suffix_bug/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.5"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -191,7 +191,7 @@ variable "template" {
  - `max_replicas` - (Optional) The maximum number of replicas for this container.
  - `min_replicas` - (Optional) The minimum number of replicas for this container.
  - `polling_interval` - (Optional) The interval in seconds at which the scaling rules are evaluated. Defaults to `30`.
- - `revision_suffix` - (Optional) The suffix for the revision. This value must be unique for the lifetime of the Resource. If omitted the service will use a hash function to create one.
+ - `revision_suffix` - (Optional - Deprecated) This field is no longer sent to Azure. Azure automatically generates a unique revision suffix using a hash function. Static values caused 'revision with suffix already exists' errors on subsequent applies (see [#115](https://github.com/Azure/terraform-azurerm-avm-res-app-containerapp/issues/115)). This variable is retained for backward compatibility but has no effect.
 
  ---
  `azure_queue_scale_rule` block supports the following:


### PR DESCRIPTION
## Description

When using this module with `revision_suffix` set (e.g., `revision_suffix = "v1"`), the **first** `terraform apply` succeeds, but any **subsequent** apply fails with:

> Field 'template.revisionsuffix' is invalid with details: 'Invalid value: revision with suffix already exists'

This happens because:

1. The module uses `azapi_resource`, which sends **PUT** requests (full resource replacement)
2. `main.tf:175` always includes `revisionSuffix = var.template.revision_suffix` in the PUT body
3. Azure Container Apps requires revision suffixes to be **unique for the lifetime of the resource** — once a revision with suffix "v1" exists, you can never create another with the same suffix
4. Every `terraform apply` re-sends the same static value → conflict

The existing `ignore_changes` on `body.properties.template.revisionSuffix` only prevents Terraform from detecting plan diffs — it does **not** prevent the value from being included in the PUT request body sent to Azure. This also blocks out-of-band deployment workflows (e.g., Azure DevOps `containerapp` tasks).

**Fix:** Remove `revisionSuffix` from the request body entirely. Azure's built-in hash function generates a unique suffix automatically when the field is omitted. The `azapi` provider v2.5+ has `ignore_missing_property = true` by default, so this won't cause perpetual drift.

**Traffic routing is unaffected** — `ingress.traffic_weight[].revision_suffix` (which maps to `revisionName`) is a separate field and is not changed.

**Backward compatibility:** The `template.revision_suffix` variable is retained in the interface so existing configs don't break. Users who were setting this field were already experiencing this bug, so this change fixes their workflow.

Closes #115

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [[pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks)](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks