### PR TITLE
fix: add ignore_null_property to resolve idempotency drift (fixes #124)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ resource "azapi_resource" "container_app" {
   create_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   read_headers              = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_null_property      = true
   response_export_values    = ["*"]
   schema_validation_enabled = false
   sensitive_body = local.sensitive_body_present ? {


### PR DESCRIPTION
## Description

When using managed identity for container registry auth (no username/password), Azure API returns empty strings for `passwordSecretRef` and `username` fields. With `response_export_values = ["*"]`, these empty strings get stored in state, causing drift on every subsequent `terraform plan` (`"" -> null`).

## Fix

Add `ignore_null_property = true` to the `azapi_resource.container_app` resource. This tells AzAPI provider to treat null values in the Terraform config body as 'don't care' when comparing against state, suppressing the false `"" -> null` drift.

## Evidence

Verified experimentally:
- **Without** `ignore_null_property`: every plan shows `passwordSecretRef = "" -> null` and `username = "" -> null`
- **With** `ignore_null_property = true`: plan shows 'No changes. Your infrastructure matches the configuration.'
- Azure REST API confirmed to return `""` (empty strings) for these fields, not null/absent

## Compatibility

- **Non-breaking**: existing users only need to upgrade module version
- **First plan after upgrade**: shows `ignore_null_property = false -> true` as in-place update
- **Subsequent plans**: clean, no drift

Fixes #124